### PR TITLE
Expose submission helpers in public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,23 @@ export type {
 } from './types/options';
 
 export type { CodexEvent } from './types/events';
-export type { SubmissionEnvelope } from './internal/submissions';
+export {
+  createUserInputSubmission,
+  createUserTurnSubmission,
+  createInterruptSubmission,
+  createPatchApprovalSubmission,
+} from './internal/submissions';
+export type {
+  SubmissionEnvelope,
+  SubmissionOp,
+  UserInputOp,
+  UserTurnOp,
+  InterruptOp,
+  ExecApprovalOp,
+  PatchApprovalOp,
+  CreateUserTurnSubmissionOptions,
+  ApprovalSubmissionOptions,
+} from './internal/submissions';
 export type {
   AskForApproval,
   SandboxPolicy,


### PR DESCRIPTION
## Summary
- export submission helper functions from the package index
- surface the related submission operation types in the public API

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ceaaf6981c8325a2b29633d02c9b53