### PR TITLE
Add client helpers for new submission APIs

### DIFF
--- a/src/client/CodexClient.ts
+++ b/src/client/CodexClient.ts
@@ -4,18 +4,24 @@ import * as path from 'path';
 import type { InputItem } from '../bindings/InputItem';
 import type { AskForApproval } from '../bindings/AskForApproval';
 import type { SandboxPolicy } from '../bindings/SandboxPolicy';
+import type { ReasoningEffort } from '../bindings/ReasoningEffort';
 import type { ReasoningSummary } from '../bindings/ReasoningSummary';
 import type { CodexEvent } from '../types/events';
 import type {
   CodexClientConfig,
   CreateConversationOptions,
+  OverrideTurnContextOptions,
   SendMessageOptions,
   SendUserTurnOptions,
 } from '../types/options';
 import type { SubmissionEnvelope } from '../internal/submissions';
 import {
+  createAddToHistorySubmission,
+  createGetPathSubmission,
   createInterruptSubmission,
+  createOverrideTurnContextSubmission,
   createPatchApprovalSubmission,
+  createShutdownSubmission,
   createUserInputSubmission,
   createUserTurnSubmission,
 } from '../internal/submissions';
@@ -43,6 +49,10 @@ const DEFAULT_SANDBOX_POLICY: SandboxPolicy = {
   exclude_tmpdir_env_var: false,
   exclude_slash_tmp: false,
 };
+
+const APPROVAL_POLICY_VALUES: readonly AskForApproval[] = ['untrusted', 'on-failure', 'on-request', 'never'];
+const REASONING_EFFORT_VALUES: readonly ReasoningEffort[] = ['minimal', 'low', 'medium', 'high'];
+const REASONING_SUMMARY_VALUES: readonly ReasoningSummary[] = ['auto', 'concise', 'detailed', 'none'];
 
 export class CodexClient extends EventEmitter {
   private native?: NativeCodexInstance;
@@ -203,6 +213,106 @@ export class CodexClient extends EventEmitter {
       decision,
       kind: 'patch',
     });
+    await this.submit(session, submission);
+  }
+
+  async overrideTurnContext(options: OverrideTurnContextOptions): Promise<void> {
+    if (!options || typeof options !== 'object') {
+      throw new TypeError('overrideTurnContext requires an options object');
+    }
+
+    const hasOverride =
+      options.cwd !== undefined ||
+      options.approvalPolicy !== undefined ||
+      options.sandboxPolicy !== undefined ||
+      options.model !== undefined ||
+      options.effort !== undefined ||
+      options.summary !== undefined;
+
+    if (!hasOverride) {
+      throw new TypeError('overrideTurnContext requires at least one override property');
+    }
+
+    const normalized: OverrideTurnContextOptions = {};
+
+    if (options.cwd !== undefined) {
+      if (typeof options.cwd !== 'string' || !options.cwd.trim()) {
+        throw new TypeError('overrideTurnContext cwd must be a non-empty string when provided');
+      }
+      normalized.cwd = options.cwd.trim();
+    }
+
+    if (options.approvalPolicy !== undefined) {
+      if (!isAskForApprovalValue(options.approvalPolicy)) {
+        throw new TypeError('overrideTurnContext approvalPolicy must be a valid AskForApproval value');
+      }
+      normalized.approvalPolicy = options.approvalPolicy;
+    }
+
+    if (options.sandboxPolicy !== undefined) {
+      if (!isSandboxPolicyValue(options.sandboxPolicy)) {
+        throw new TypeError('overrideTurnContext sandboxPolicy must be a valid SandboxPolicy value');
+      }
+      normalized.sandboxPolicy = options.sandboxPolicy;
+    }
+
+    let normalizedEffort: ReasoningEffort | null | undefined = options.effort;
+    if (normalizedEffort !== undefined && normalizedEffort !== null && !isReasoningEffortValue(normalizedEffort)) {
+      throw new TypeError('overrideTurnContext effort must be minimal, low, medium, high or null');
+    }
+
+    if (options.model !== undefined) {
+      if (typeof options.model !== 'string' || !options.model.trim()) {
+        throw new TypeError('overrideTurnContext model must be a non-empty string when provided');
+      }
+      const trimmedModel = options.model.trim();
+      const effortForResolution =
+        normalizedEffort !== undefined && normalizedEffort !== null ? normalizedEffort : undefined;
+      const resolved = resolveModelVariant(trimmedModel, effortForResolution);
+      normalized.model = resolved.model;
+      if (normalizedEffort !== undefined && normalizedEffort !== null) {
+        normalizedEffort = resolved.effort;
+      }
+    }
+
+    if (normalizedEffort !== undefined) {
+      normalized.effort = normalizedEffort;
+    }
+
+    if (options.summary !== undefined) {
+      if (!isReasoningSummaryValue(options.summary)) {
+        throw new TypeError('overrideTurnContext summary must be auto, concise, detailed or none');
+      }
+      normalized.summary = options.summary;
+    }
+
+    const session = this.requireSession();
+    const submission = createOverrideTurnContextSubmission(this.generateRequestId(), normalized);
+    await this.submit(session, submission);
+  }
+
+  async addToHistory(text: string): Promise<void> {
+    if (typeof text !== 'string') {
+      throw new TypeError('addToHistory text must be a string');
+    }
+    if (!text.trim()) {
+      throw new TypeError('addToHistory text cannot be empty');
+    }
+
+    const session = this.requireSession();
+    const submission = createAddToHistorySubmission(this.generateRequestId(), text);
+    await this.submit(session, submission);
+  }
+
+  async getPath(): Promise<void> {
+    const session = this.requireSession();
+    const submission = createGetPathSubmission(this.generateRequestId());
+    await this.submit(session, submission);
+  }
+
+  async shutdown(): Promise<void> {
+    const session = this.requireSession();
+    const submission = createShutdownSubmission(this.generateRequestId());
     await this.submit(session, submission);
   }
 
@@ -406,6 +516,15 @@ export class CodexClient extends EventEmitter {
       case 'notification':
         this.emit('notification', event.msg);
         break;
+      case 'conversation_path':
+        this.emit('conversationPath', event.msg);
+        break;
+      case 'shutdown_complete':
+        this.emit('shutdownComplete', event.msg);
+        break;
+      case 'turn_context':
+        this.emit('turnContext', event.msg);
+        break;
       default:
         break;
     }
@@ -489,6 +608,94 @@ export class CodexClient extends EventEmitter {
       details,
     });
   }
+}
+
+type WorkspaceWriteSandboxPolicy = Extract<SandboxPolicy, { mode: 'workspace-write' }>;
+
+function isAskForApprovalValue(value: unknown): value is AskForApproval {
+  return typeof value === 'string' && (APPROVAL_POLICY_VALUES as readonly string[]).includes(value);
+}
+
+function isReasoningEffortValue(value: unknown): value is ReasoningEffort {
+  return typeof value === 'string' && (REASONING_EFFORT_VALUES as readonly string[]).includes(value);
+}
+
+function isReasoningSummaryValue(value: unknown): value is ReasoningSummary {
+  return typeof value === 'string' && (REASONING_SUMMARY_VALUES as readonly string[]).includes(value);
+}
+
+function isSandboxPolicyValue(value: unknown): value is SandboxPolicy {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as { mode?: unknown };
+  if (candidate.mode === 'danger-full-access' || candidate.mode === 'read-only') {
+    return true;
+  }
+
+  if (candidate.mode === 'workspace-write') {
+    const workspacePolicy = value as WorkspaceWriteSandboxPolicy;
+    if (
+      typeof workspacePolicy.network_access !== 'boolean' ||
+      typeof workspacePolicy.exclude_tmpdir_env_var !== 'boolean' ||
+      typeof workspacePolicy.exclude_slash_tmp !== 'boolean'
+    ) {
+      return false;
+    }
+
+    if (
+      workspacePolicy.writable_roots !== undefined &&
+      (!Array.isArray(workspacePolicy.writable_roots) ||
+        workspacePolicy.writable_roots.some((entry) => typeof entry !== 'string'))
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+type CodexClientEventListener<T> = (event: T) => void;
+
+export interface ConversationPathEventMessage {
+  type: 'conversation_path';
+  conversation_id: string;
+  path: string;
+}
+
+export interface ShutdownCompleteEventMessage {
+  type: 'shutdown_complete';
+}
+
+export interface TurnContextEventMessage {
+  type: 'turn_context';
+  cwd: string;
+  approval_policy: AskForApproval;
+  sandbox_policy: SandboxPolicy;
+  model: string;
+  effort?: ReasoningEffort | null;
+  summary: ReasoningSummary;
+}
+
+export interface CodexClient {
+  on(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
+  on(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
+  on(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+
+  once(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
+  once(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
+  once(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+
+  off(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
+  off(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
+  off(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+
+  on(event: string, listener: (...args: unknown[]) => void): this;
+  once(event: string, listener: (...args: unknown[]) => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this;
 }
 
 function expandHomePath(input: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,17 @@ export { CodexClientPool } from './client/CodexClientPool';
 export type {
   CodexClientConfig,
   CreateConversationOptions,
+  OverrideTurnContextOptions,
   SendUserTurnOptions,
   SendMessageOptions,
 } from './types/options';
 
 export type { CodexEvent } from './types/events';
+export type {
+  ConversationPathEventMessage,
+  ShutdownCompleteEventMessage,
+  TurnContextEventMessage,
+} from './client/CodexClient';
 export type { SubmissionEnvelope } from './internal/submissions';
 export type {
   AskForApproval,

--- a/src/internal/submissions.ts
+++ b/src/internal/submissions.ts
@@ -4,6 +4,7 @@ import type { SandboxPolicy } from '../bindings/SandboxPolicy';
 import type { ReasoningEffort } from '../bindings/ReasoningEffort';
 import type { ReasoningSummary } from '../bindings/ReasoningSummary';
 import type { ReviewDecision } from '../bindings/ReviewDecision';
+import type { OverrideTurnContextOptions } from '../types/options';
 
 export interface SubmissionEnvelope<T extends SubmissionOp = SubmissionOp> {
   id: string;
@@ -15,7 +16,11 @@ export type SubmissionOp =
   | UserTurnOp
   | InterruptOp
   | ExecApprovalOp
-  | PatchApprovalOp;
+  | PatchApprovalOp
+  | OverrideTurnContextOp
+  | AddToHistoryOp
+  | GetPathOp
+  | ShutdownOp;
 
 export interface UserInputOp {
   type: 'user_input';
@@ -49,6 +54,29 @@ export interface PatchApprovalOp {
   decision: ReviewDecision;
 }
 
+export interface OverrideTurnContextOp {
+  type: 'override_turn_context';
+  cwd?: string;
+  approval_policy?: AskForApproval;
+  sandbox_policy?: SandboxPolicy;
+  model?: string;
+  effort?: ReasoningEffort | null;
+  summary?: ReasoningSummary;
+}
+
+export interface AddToHistoryOp {
+  type: 'add_to_history';
+  text: string;
+}
+
+export interface GetPathOp {
+  type: 'get_path';
+}
+
+export interface ShutdownOp {
+  type: 'shutdown';
+}
+
 export interface CreateUserTurnSubmissionOptions {
   items: InputItem[];
   cwd: string;
@@ -64,6 +92,8 @@ export interface ApprovalSubmissionOptions {
   decision: 'approve' | 'reject';
   kind: 'exec' | 'patch';
 }
+
+export type OverrideTurnContextSubmissionOptions = OverrideTurnContextOptions;
 
 export function createUserInputSubmission(id: string, items: InputItem[]): SubmissionEnvelope<UserInputOp> {
   return {
@@ -128,6 +158,72 @@ export function createPatchApprovalSubmission(
       type: 'patch_approval',
       id: options.id,
       decision,
+    },
+  };
+}
+
+export function createOverrideTurnContextSubmission(
+  id: string,
+  options: OverrideTurnContextSubmissionOptions,
+): SubmissionEnvelope<OverrideTurnContextOp> {
+  const op: OverrideTurnContextOp = {
+    type: 'override_turn_context',
+  };
+
+  if (options.cwd !== undefined) {
+    op.cwd = options.cwd;
+  }
+
+  if (options.approvalPolicy !== undefined) {
+    op.approval_policy = options.approvalPolicy;
+  }
+
+  if (options.sandboxPolicy !== undefined) {
+    op.sandbox_policy = options.sandboxPolicy;
+  }
+
+  if (options.model !== undefined) {
+    op.model = options.model;
+  }
+
+  if (options.effort !== undefined) {
+    op.effort = options.effort;
+  }
+
+  if (options.summary !== undefined) {
+    op.summary = options.summary;
+  }
+
+  return { id, op };
+}
+
+export function createAddToHistorySubmission(
+  id: string,
+  text: string,
+): SubmissionEnvelope<AddToHistoryOp> {
+  return {
+    id,
+    op: {
+      type: 'add_to_history',
+      text,
+    },
+  };
+}
+
+export function createGetPathSubmission(id: string): SubmissionEnvelope<GetPathOp> {
+  return {
+    id,
+    op: {
+      type: 'get_path',
+    },
+  };
+}
+
+export function createShutdownSubmission(id: string): SubmissionEnvelope<ShutdownOp> {
+  return {
+    id,
+    op: {
+      type: 'shutdown',
     },
   };
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -25,6 +25,15 @@ export interface CreateConversationOptions {
   overrides?: Record<string, string>;
 }
 
+export interface OverrideTurnContextOptions {
+  cwd?: string;
+  approvalPolicy?: AskForApproval;
+  sandboxPolicy?: SandboxPolicy;
+  model?: string;
+  effort?: ReasoningEffort | null;
+  summary?: ReasoningSummary;
+}
+
 export interface SendUserTurnOptions {
   cwd?: string;
   approvalPolicy?: AskForApproval;

--- a/tests/CodexClient.test.ts
+++ b/tests/CodexClient.test.ts
@@ -202,6 +202,116 @@ describe('CodexClient', () => {
     await client.close().catch(() => undefined);
   });
 
+  it('overrides turn context through submissions', async () => {
+    const client = createClient();
+    await client.createConversation();
+    nextEventMock.mockResolvedValueOnce(null);
+
+    await client.overrideTurnContext({
+      cwd: '/tmp/workspace',
+      approvalPolicy: 'never',
+      sandboxPolicy: { mode: 'read-only' },
+      model: 'codex',
+      effort: 'high',
+      summary: 'concise',
+    });
+
+    const payload = JSON.parse(submitMock.mock.calls[0][0]);
+    expect(payload.op).toMatchObject({
+      type: 'override_turn_context',
+      cwd: '/tmp/workspace',
+      approval_policy: 'never',
+      sandbox_policy: { mode: 'read-only' },
+      model: 'gpt-5-codex',
+      effort: 'high',
+      summary: 'concise',
+    });
+  });
+
+  it('validates override turn context input', async () => {
+    const client = createClient();
+    await client.createConversation();
+
+    await expect(client.overrideTurnContext({})).rejects.toThrow(/at least one override property/);
+    await expect(
+      client.overrideTurnContext({ effort: 'invalid' as unknown as 'minimal' }),
+    ).rejects.toThrow(/effort must be minimal/);
+  });
+
+  it('adds entries to history via submissions', async () => {
+    const client = createClient();
+    await client.createConversation();
+    nextEventMock.mockResolvedValueOnce(null);
+
+    await client.addToHistory('Remember this');
+
+    const payload = JSON.parse(submitMock.mock.calls[0][0]);
+    expect(payload.op).toEqual({ type: 'add_to_history', text: 'Remember this' });
+  });
+
+  it('rejects blank history entries', async () => {
+    const client = createClient();
+    await client.createConversation();
+
+    await expect(client.addToHistory('   ')).rejects.toThrow(/cannot be empty/);
+  });
+
+  it('requests conversation path and shutdown submissions', async () => {
+    const client = createClient();
+    await client.createConversation();
+    nextEventMock.mockResolvedValueOnce(null);
+
+    await client.getPath();
+    await client.shutdown();
+
+    expect(submitMock.mock.calls).toHaveLength(2);
+    const firstPayload = JSON.parse(submitMock.mock.calls[0][0]);
+    const secondPayload = JSON.parse(submitMock.mock.calls[1][0]);
+    expect(firstPayload.op).toEqual({ type: 'get_path' });
+    expect(secondPayload.op).toEqual({ type: 'shutdown' });
+  });
+
+  it('routes new event types through routeEvent', async () => {
+    const client = createClient();
+    const conversationPathListener = vi.fn();
+    const shutdownListener = vi.fn();
+    const turnContextListener = vi.fn();
+
+    client.on('conversationPath', conversationPathListener);
+    client.on('shutdownComplete', shutdownListener);
+    client.on('turnContext', turnContextListener);
+
+    const clientWithRoute = client as unknown as { routeEvent: (event: ReturnType<typeof makeEvent>) => void };
+
+    clientWithRoute.routeEvent(
+      makeEvent('conversation_path', { conversation_id: 'conv-123', path: '/tmp/history' }),
+    );
+    clientWithRoute.routeEvent(makeEvent('shutdown_complete'));
+    clientWithRoute.routeEvent(
+      makeEvent('turn_context', {
+        cwd: '/tmp',
+        approval_policy: 'on-request',
+        sandbox_policy: {
+          mode: 'workspace-write',
+          network_access: false,
+          exclude_tmpdir_env_var: false,
+          exclude_slash_tmp: false,
+        },
+        model: 'gpt-5-codex',
+        effort: 'medium',
+        summary: 'auto',
+      }),
+    );
+
+    expect(conversationPathListener).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/tmp/history' }),
+    );
+    expect(shutdownListener).toHaveBeenCalledWith(expect.objectContaining({ type: 'shutdown_complete' }));
+    expect(turnContextListener).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp', model: 'gpt-5-codex' }),
+    );
+  });
+
   it('closes sessions gracefully', async () => {
     const client = createClient();
     let resolveNext: ((value: string | null) => void) | undefined;


### PR DESCRIPTION
## Summary
- extend internal submission helpers to support overriding turn context, recording history, retrieving conversation paths, and shutting down a session
- add corresponding CodexClient methods with runtime validation, plugin participation, and event re-emission
- export new options/event types and expand unit coverage for the additional behaviours

## Testing
- npm test *(fails: example suite cannot resolve the package entry point in this workspace)*
- npx vitest run --run tests/CodexClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ceaab0877c8325acd5394487148ccb