### PR TITLE
Add submission variants and builders

### DIFF
--- a/src/client/CodexClient.ts
+++ b/src/client/CodexClient.ts
@@ -15,6 +15,7 @@ import type {
 import type { SubmissionEnvelope } from '../internal/submissions';
 import {
   createInterruptSubmission,
+  createExecApprovalSubmission,
   createPatchApprovalSubmission,
   createUserInputSubmission,
   createUserTurnSubmission,
@@ -188,10 +189,9 @@ export class CodexClient extends EventEmitter {
 
   async respondToExecApproval(requestId: string, decision: 'approve' | 'reject'): Promise<void> {
     const session = this.requireSession();
-    const submission = createPatchApprovalSubmission(this.generateRequestId(), {
+    const submission = createExecApprovalSubmission(this.generateRequestId(), {
       id: requestId,
       decision,
-      kind: 'exec',
     });
     await this.submit(session, submission);
   }
@@ -201,7 +201,6 @@ export class CodexClient extends EventEmitter {
     const submission = createPatchApprovalSubmission(this.generateRequestId(), {
       id: requestId,
       decision,
-      kind: 'patch',
     });
     await this.submit(session, submission);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type {
 } from './types/options';
 
 export type { CodexEvent } from './types/events';
-export type { SubmissionEnvelope } from './internal/submissions';
+export type { SubmissionEnvelope, SubmissionOp, ReviewRequest } from './internal/submissions';
 export type {
   AskForApproval,
   SandboxPolicy,


### PR DESCRIPTION
## Summary
- add interfaces for the remaining submission operations and expose a ReviewRequest helper type
- provide strongly typed builders for the new operations and split exec/patch approval helpers
- update the client to use the dedicated exec approval builder

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cea98a6fb08325852cf39f1e1aeec2