### PR TITLE
Add Codex turn context overrides and new events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-ts-sdk",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-ts-sdk",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-ts-sdk",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "TypeScript client for Codex native runtime",
   "license": "MIT",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,17 @@ export { CodexClientPool } from './client/CodexClientPool';
 export type {
   CodexClientConfig,
   CreateConversationOptions,
+  OverrideTurnContextOptions,
   SendUserTurnOptions,
   SendMessageOptions,
 } from './types/options';
 
 export type { CodexEvent } from './types/events';
+export type {
+  ConversationPathEventMessage,
+  ShutdownCompleteEventMessage,
+  TurnContextEventMessage,
+} from './client/CodexClient';
 export type { SubmissionEnvelope, SubmissionOp, ReviewRequest } from './internal/submissions';
 export type {
   AskForApproval,

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -25,6 +25,15 @@ export interface CreateConversationOptions {
   overrides?: Record<string, string>;
 }
 
+export interface OverrideTurnContextOptions {
+  cwd?: string;
+  approvalPolicy?: AskForApproval;
+  sandboxPolicy?: SandboxPolicy;
+  model?: string;
+  effort?: ReasoningEffort | null;
+  summary?: ReasoningSummary;
+}
+
 export interface SendUserTurnOptions {
   cwd?: string;
   approvalPolicy?: AskForApproval;

--- a/tests/internal/submissions.test.ts
+++ b/tests/internal/submissions.test.ts
@@ -5,60 +5,131 @@ import {
   createUserInputSubmission,
   createUserTurnSubmission,
 } from '../../src/internal/submissions';
-
 import type { InputItem } from '../../src/bindings/InputItem';
 
 describe('submission helpers', () => {
-  it('creates user input submissions', () => {
-    const submission = createUserInputSubmission('id-1', [{ type: 'text', text: 'hello' }]);
-    expect(submission).toEqual({ id: 'id-1', op: { type: 'user_input', items: [{ type: 'text', text: 'hello' }] } });
-  });
+  describe('createUserInputSubmission', () => {
+    it('wraps provided items in a user_input envelope', () => {
+      const items: InputItem[] = [
+        { type: 'text', text: 'Hello Codex' },
+        { type: 'localImage', path: '/tmp/image.png' },
+      ];
 
-  it('creates user turn submissions including optional effort', () => {
-    const items: InputItem[] = [{ type: 'text', text: 'run' }];
-    const submission = createUserTurnSubmission('turn', {
-      items,
-      cwd: '/tmp',
-      approvalPolicy: 'on-request',
-      sandboxPolicy: { mode: 'workspace-write', network_access: false, exclude_slash_tmp: false, exclude_tmpdir_env_var: false },
-      model: 'codex',
-      summary: 'concise',
-      effort: 'high',
-    });
-    expect(submission.op).toMatchObject({
-      type: 'user_turn',
-      items,
-      cwd: '/tmp',
-      approval_policy: 'on-request',
-      sandbox_policy: expect.objectContaining({ mode: 'workspace-write' }),
-      model: 'codex',
-      summary: 'concise',
-      effort: 'high',
+      const submission = createUserInputSubmission('req-1', items);
+
+      expect(submission).toEqual({
+        id: 'req-1',
+        op: {
+          type: 'user_input',
+          items,
+        },
+      });
     });
   });
 
-  it('omits effort when not provided', () => {
-    const items: InputItem[] = [{ type: 'text', text: 'test' }];
-    const submission = createUserTurnSubmission('turn', {
-      items,
-      cwd: '/tmp',
-      approvalPolicy: 'on-request',
-      sandboxPolicy: { mode: 'workspace-write', network_access: true, exclude_slash_tmp: false, exclude_tmpdir_env_var: false },
-      model: 'codex',
-      summary: 'auto',
+  describe('createUserTurnSubmission', () => {
+    it('returns a fully populated user_turn envelope when all fields are provided', () => {
+      const items: InputItem[] = [{ type: 'text', text: 'Summarise progress' }];
+      const submission = createUserTurnSubmission('req-2', {
+        items,
+        cwd: '/workspace/project',
+        approvalPolicy: 'on-request',
+        sandboxPolicy: {
+          mode: 'workspace-write',
+          network_access: true,
+          exclude_tmpdir_env_var: false,
+          exclude_slash_tmp: false,
+        },
+        model: 'gpt-5-codex',
+        effort: 'medium',
+        summary: 'summary goes here',
+      });
+
+      expect(submission).toEqual({
+        id: 'req-2',
+        op: {
+          type: 'user_turn',
+          items,
+          cwd: '/workspace/project',
+          approval_policy: 'on-request',
+          sandbox_policy: {
+            mode: 'workspace-write',
+            network_access: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+          },
+          model: 'gpt-5-codex',
+          effort: 'medium',
+          summary: 'summary goes here',
+        },
+      });
     });
-    expect(submission.op).not.toHaveProperty('effort');
+
+    it('omits effort when no value is supplied', () => {
+      const submission = createUserTurnSubmission('req-3', {
+        items: [{ type: 'text', text: 'No effort provided' }],
+        cwd: '/workspace/project',
+        approvalPolicy: 'never',
+        sandboxPolicy: {
+          mode: 'workspace-write',
+          network_access: false,
+          exclude_tmpdir_env_var: false,
+          exclude_slash_tmp: false,
+        },
+        model: 'gpt-5-codex',
+        summary: 'auto',
+      });
+
+      expect(submission.id).toBe('req-3');
+      expect(submission.op.type).toBe('user_turn');
+      expect(submission.op).not.toHaveProperty('effort');
+    });
   });
 
-  it('creates interrupt submissions', () => {
-    expect(createInterruptSubmission('interrupt')).toEqual({ id: 'interrupt', op: { type: 'interrupt' } });
+  describe('createInterruptSubmission', () => {
+    it('creates an interrupt envelope with no additional data', () => {
+      expect(createInterruptSubmission('req-4')).toEqual({
+        id: 'req-4',
+        op: {
+          type: 'interrupt',
+        },
+      });
+    });
   });
 
-  it('creates approval submissions for exec and patch decisions', () => {
-    const exec = createPatchApprovalSubmission('id', { id: 'exec-1', decision: 'approve', kind: 'exec' });
-    expect(exec.op).toEqual({ type: 'exec_approval', id: 'exec-1', decision: 'approved' });
+  describe('createPatchApprovalSubmission', () => {
+    it('maps exec approvals with approve decisions to the expected envelope', () => {
+      const submission = createPatchApprovalSubmission('req-5', {
+        id: 'approval-1',
+        decision: 'approve',
+        kind: 'exec',
+      });
 
-    const patch = createPatchApprovalSubmission('id-2', { id: 'patch-1', decision: 'reject', kind: 'patch' });
-    expect(patch.op).toEqual({ type: 'patch_approval', id: 'patch-1', decision: 'denied' });
+      expect(submission).toEqual({
+        id: 'req-5',
+        op: {
+          type: 'exec_approval',
+          id: 'approval-1',
+          decision: 'approved',
+        },
+      });
+    });
+
+    it('maps patch rejections to denied patch approval envelopes', () => {
+      const submission = createPatchApprovalSubmission('req-6', {
+        id: 'approval-2',
+        decision: 'reject',
+        kind: 'patch',
+      });
+
+      expect(submission).toEqual({
+        id: 'req-6',
+        op: {
+          type: 'patch_approval',
+          id: 'approval-2',
+          decision: 'denied',
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add CodexClient helpers for override turn context, history, get_path, and shutdown submissions
- validate override inputs, surface new conversation path/shutdown/turn context events, and export their types
- expose OverrideTurnContextOptions so internal builders stay aligned with the SDK API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cec25cd98c83258bd67ec1dcb2c792