### PR TITLE
Expose remaining protocol operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,12 +325,12 @@ Set the `CODEX_HOME` environment variable (or pass `codexHome`) to the directory
 | `UserTurn` | `CodexClient.sendUserTurn()` → `createUserTurnSubmission()` (`src/client/CodexClient.ts:160`) | `tests/CodexClient.behavior.test.ts`, `tests/integration/CodexClient.integration.test.ts`, `tests/examples/examples.test.ts` | Covered. |
 | `ExecApproval` | `CodexClient.respondToExecApproval()` (`src/client/CodexClient.ts:194`) | `tests/CodexClient.behavior.test.ts`, `tests/integration/CodexClient.integration.test.ts`, `tests/examples/examples.test.ts` | Covered. |
 | `PatchApproval` | `CodexClient.respondToPatchApproval()` (`src/client/CodexClient.ts:205`) | `tests/CodexClient.behavior.test.ts`, `tests/integration/CodexClient.integration.test.ts`, `tests/examples/examples.test.ts` | Covered. |
-| `OverrideTurnContext` | — | — | Currently not exposed via the SDK. |
-| `AddToHistory` | — | — | Currently not exposed via the SDK. |
-| `GetHistoryEntryRequest` | — | — | Currently not exposed via the SDK. |
-| `GetPath` | — | — | Currently not exposed via the SDK. |
-| `ListMcpTools` | — | — | Currently not exposed via the SDK. |
-| `ListCustomPrompts` | — | — | Currently not exposed via the SDK. |
-| `Compact` | — | — | Currently not exposed via the SDK. |
-| `Review` | — | — | Currently not exposed via the SDK. |
-| `Shutdown` | — | — | Currently not exposed via the SDK. |
+| `OverrideTurnContext` | `CodexClient.overrideTurnContext()` → `createOverrideTurnContextSubmission()` (`src/client/CodexClient.ts:216`) | `tests/CodexClient.test.ts` | Covered. |
+| `AddToHistory` | `CodexClient.addToHistory()` → `createAddToHistorySubmission()` (`src/client/CodexClient.ts:279`) | `tests/CodexClient.test.ts` | Covered. |
+| `GetHistoryEntryRequest` | `CodexClient.getHistoryEntry()` → `createGetHistoryEntryRequestSubmission()` (`src/client/CodexClient.ts:296`) | `tests/CodexClient.test.ts` | Covered. |
+| `GetPath` | `CodexClient.getPath()` → `createGetPathSubmission()` (`src/client/CodexClient.ts:320`) | `tests/CodexClient.test.ts` | Covered. |
+| `ListMcpTools` | `CodexClient.listMcpTools()` → `createListMcpToolsSubmission()` (`src/client/CodexClient.ts:304`) | `tests/CodexClient.test.ts` | Covered. |
+| `ListCustomPrompts` | `CodexClient.listCustomPrompts()` → `createListCustomPromptsSubmission()` (`src/client/CodexClient.ts:308`) | `tests/CodexClient.test.ts` | Covered. |
+| `Compact` | `CodexClient.compact()` → `createCompactSubmission()` (`src/client/CodexClient.ts:312`) | `tests/CodexClient.test.ts` | Covered. |
+| `Review` | `CodexClient.review()` → `createReviewSubmission()` (`src/client/CodexClient.ts:316`) | `tests/CodexClient.test.ts` | Covered. |
+| `Shutdown` | `CodexClient.shutdown()` → `createShutdownSubmission()` (`src/client/CodexClient.ts:324`) | `tests/CodexClient.test.ts` | Covered. |

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -1,0 +1,25 @@
+# Sprint Plan: Protocol Coverage Completion
+
+This plan breaks down the remaining protocol operations work into three focused 30-minute sprints. Each sprint includes concrete tasks, expected deliverables, and success criteria.
+
+## Sprint 1 (0–30 minutes): Documentation Sync & API Blueprint
+- [ ] Update the README protocol coverage table to accurately reflect exposed operations and identify outstanding gaps.
+- [ ] Review existing submission builder helpers for `get_history_entry_request`, `list_mcp_tools`, `list_custom_prompts`, `compact`, and `review` to confirm payload shapes.
+- [ ] Draft method signatures and validation requirements for the new `CodexClient` APIs that will wrap each helper.
+- **Exit criteria:** README accurately lists implemented vs. missing operations, and design notes exist outlining parameters/return types for upcoming client methods.
+
+## Sprint 2 (30–60 minutes): Implement History & Listing APIs
+- [ ] Implement `CodexClient.getHistoryEntry`, `CodexClient.listMcpTools`, and `CodexClient.listCustomPrompts`, wired to their respective submission builders with validation.
+- [ ] Extend shared types/event routing as needed to support responses or events emitted by these operations.
+- [ ] Add Vitest coverage verifying payload submission, validation behavior, and event routing for each new method.
+- **Exit criteria:** Client exposes the history/listing APIs with comprehensive unit tests, and type definitions accommodate emitted events.
+
+## Sprint 3 (60–90 minutes): Implement Maintenance & Review Flows
+- [ ] Implement `CodexClient.compact` and `CodexClient.review`, leveraging existing submission helpers and enforcing input validation.
+- [ ] Create unit tests covering payload construction, validation errors, and event routing for both methods.
+- [ ] Run the full test suite (e.g., `npm run test`) and update README/API reference documentation with the new APIs.
+- **Exit criteria:** Maintenance/review operations are exposed with passing tests, and documentation reflects complete protocol coverage.
+
+## Tracking & Follow-Up
+- During each sprint, capture notes on blockers or follow-up work items.
+- After Sprint 3, reassess whether additional integration tests or examples are needed before releasing the updated SDK.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,11 @@ export { CodexClientPool } from './client/CodexClientPool';
 export type {
   CodexClientConfig,
   CreateConversationOptions,
+  GetHistoryEntryRequestOptions,
   OverrideTurnContextOptions,
+  ReviewRequestCamelCaseInput,
+  ReviewRequestInput,
+  ReviewRequestSnakeCaseInput,
   SendUserTurnOptions,
   SendMessageOptions,
 } from './types/options';
@@ -13,8 +17,20 @@ export type {
 export type { CodexEvent } from './types/events';
 export type {
   ConversationPathEventMessage,
+  CustomPromptDefinition,
+  EnteredReviewModeEventMessage,
+  ExitedReviewModeEventMessage,
+  GetHistoryEntryResponseEventMessage,
+  HistoryEntryEvent,
   ShutdownCompleteEventMessage,
   TurnContextEventMessage,
+  ListCustomPromptsResponseEventMessage,
+  McpListToolsResponseEventMessage,
+  McpToolDefinition,
+  ReviewCodeLocation,
+  ReviewFinding,
+  ReviewLineRange,
+  ReviewOutputEventMessage,
 } from './client/CodexClient';
 export type { SubmissionEnvelope, SubmissionOp, ReviewRequest } from './internal/submissions';
 export type {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -47,3 +47,20 @@ export interface SendUserTurnOptions {
 export interface SendMessageOptions {
   images?: string[];
 }
+
+export interface GetHistoryEntryRequestOptions {
+  offset: number;
+  logId: number;
+}
+
+export interface ReviewRequestSnakeCaseInput {
+  prompt: string;
+  user_facing_hint: string;
+}
+
+export interface ReviewRequestCamelCaseInput {
+  prompt: string;
+  userFacingHint: string;
+}
+
+export type ReviewRequestInput = ReviewRequestSnakeCaseInput | ReviewRequestCamelCaseInput;


### PR DESCRIPTION
## Summary
- expose the remaining Codex protocol operations on `CodexClient`, including history access, MCP listings, compact, and review helpers
- add normalization and validation logic plus new strongly typed events and exports for the additional protocol responses
- refresh README protocol coverage to reflect the newly supported operations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cedd4d6410832597676a0741f4786d