### PR TITLE
Handle CodexClientPool waiters during close

### DIFF
--- a/tests/CodexClientPool.test.ts
+++ b/tests/CodexClientPool.test.ts
@@ -68,4 +68,17 @@ describe('CodexClientPool', () => {
 
     expect(instances.every((c) => c.close.mock.calls.length >= 1)).toBe(true);
   });
+
+  it('rejects queued acquires when closing', async () => {
+    const pool = new CodexClientPool({ codexHome: '/codex' }, 1);
+    const first = await pool.acquire();
+    const queued = pool.acquire();
+
+    const closePromise = pool.close();
+
+    await expect(queued).rejects.toThrowError('CodexClientPool is closing');
+    await closePromise;
+
+    expect(first.close).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- store resolve and reject callbacks for CodexClientPool waiters
- reject pending acquires when the pool is closed
- add coverage for closing with a queued acquire

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef88f32fc8325928a7b31d71b261e