### PR TITLE
Add typed CodexClient approval and notification events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,16 @@ export type {
 
 export type { CodexEvent } from './types/events';
 export type {
+  ApplyPatchApprovalRequestEventMessage,
   ConversationPathEventMessage,
   CustomPromptDefinition,
   EnteredReviewModeEventMessage,
   ExitedReviewModeEventMessage,
   GetHistoryEntryResponseEventMessage,
   HistoryEntryEvent,
+  ExecApprovalRequestEventMessage,
+  NotificationEventMessage,
+  SessionConfiguredEventMessage,
   ShutdownCompleteEventMessage,
   TurnContextEventMessage,
   ListCustomPromptsResponseEventMessage,


### PR DESCRIPTION
## Summary
- add strongly typed payloads for session configuration, approval request, and notification events in `CodexClient`
- expose the new event message types through the public SDK surface
- extend CodexClient routing tests to cover the additional event listeners

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef90dc0008325a19aadf9225c900a