### PR TITLE
Fix CodexClient event typings for lint

### DIFF
--- a/src/client/CodexClient.ts
+++ b/src/client/CodexClient.ts
@@ -723,6 +723,147 @@ export class CodexClient extends EventEmitter {
     }
   }
 
+  on(
+    event: 'sessionConfigured',
+    listener: CodexClientEventListener<SessionConfiguredEventMessage>,
+  ): this;
+  on(
+    event: 'execCommandApproval',
+    listener: CodexClientEventListener<ExecApprovalRequestEventMessage>,
+  ): this;
+  on(
+    event: 'applyPatchApproval',
+    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
+  ): this;
+  on(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
+  on(
+    event: 'conversationPath',
+    listener: CodexClientEventListener<ConversationPathEventMessage>,
+  ): this;
+  on(
+    event: 'shutdownComplete',
+    listener: CodexClientEventListener<ShutdownCompleteEventMessage>,
+  ): this;
+  on(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+  on(
+    event: 'historyEntry',
+    listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>,
+  ): this;
+  on(event: 'mcpTools', listener: CodexClientEventListener<McpListToolsResponseEventMessage>): this;
+  on(
+    event: 'customPrompts',
+    listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>,
+  ): this;
+  on(
+    event: 'enteredReviewMode',
+    listener: CodexClientEventListener<EnteredReviewModeEventMessage>,
+  ): this;
+  on(
+    event: 'exitedReviewMode',
+    listener: CodexClientEventListener<ExitedReviewModeEventMessage>,
+  ): this;
+  on(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
+  on(event: 'error', listener: (error: unknown) => void): this;
+  on(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
+  on(event: string, listener: (...args: unknown[]) => void): this {
+    return super.on(event, listener as (...args: unknown[]) => void);
+  }
+
+  once(
+    event: 'sessionConfigured',
+    listener: CodexClientEventListener<SessionConfiguredEventMessage>,
+  ): this;
+  once(
+    event: 'execCommandApproval',
+    listener: CodexClientEventListener<ExecApprovalRequestEventMessage>,
+  ): this;
+  once(
+    event: 'applyPatchApproval',
+    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
+  ): this;
+  once(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
+  once(
+    event: 'conversationPath',
+    listener: CodexClientEventListener<ConversationPathEventMessage>,
+  ): this;
+  once(
+    event: 'shutdownComplete',
+    listener: CodexClientEventListener<ShutdownCompleteEventMessage>,
+  ): this;
+  once(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+  once(
+    event: 'historyEntry',
+    listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>,
+  ): this;
+  once(
+    event: 'mcpTools',
+    listener: CodexClientEventListener<McpListToolsResponseEventMessage>,
+  ): this;
+  once(
+    event: 'customPrompts',
+    listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>,
+  ): this;
+  once(
+    event: 'enteredReviewMode',
+    listener: CodexClientEventListener<EnteredReviewModeEventMessage>,
+  ): this;
+  once(
+    event: 'exitedReviewMode',
+    listener: CodexClientEventListener<ExitedReviewModeEventMessage>,
+  ): this;
+  once(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
+  once(event: 'error', listener: (error: unknown) => void): this;
+  once(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
+  once(event: string, listener: (...args: unknown[]) => void): this {
+    return super.once(event, listener as (...args: unknown[]) => void);
+  }
+
+  off(
+    event: 'sessionConfigured',
+    listener: CodexClientEventListener<SessionConfiguredEventMessage>,
+  ): this;
+  off(
+    event: 'execCommandApproval',
+    listener: CodexClientEventListener<ExecApprovalRequestEventMessage>,
+  ): this;
+  off(
+    event: 'applyPatchApproval',
+    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
+  ): this;
+  off(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
+  off(
+    event: 'conversationPath',
+    listener: CodexClientEventListener<ConversationPathEventMessage>,
+  ): this;
+  off(
+    event: 'shutdownComplete',
+    listener: CodexClientEventListener<ShutdownCompleteEventMessage>,
+  ): this;
+  off(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
+  off(
+    event: 'historyEntry',
+    listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>,
+  ): this;
+  off(event: 'mcpTools', listener: CodexClientEventListener<McpListToolsResponseEventMessage>): this;
+  off(
+    event: 'customPrompts',
+    listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>,
+  ): this;
+  off(
+    event: 'enteredReviewMode',
+    listener: CodexClientEventListener<EnteredReviewModeEventMessage>,
+  ): this;
+  off(
+    event: 'exitedReviewMode',
+    listener: CodexClientEventListener<ExitedReviewModeEventMessage>,
+  ): this;
+  off(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
+  off(event: 'error', listener: (error: unknown) => void): this;
+  off(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
+  off(event: string, listener: (...args: unknown[]) => void): this {
+    return super.off(event, listener as (...args: unknown[]) => void);
+  }
+
   private requireSession(): CodexSessionHandle {
     if (!this.session) {
       throw new CodexSessionError('No active Codex session. Call createConversation first.');
@@ -944,68 +1085,6 @@ export interface ExitedReviewModeEventMessage extends CodexEventMessage {
   review_output?: ReviewOutputEventMessage;
 }
 
-export interface CodexClient {
-  on(event: 'sessionConfigured', listener: CodexClientEventListener<SessionConfiguredEventMessage>): this;
-  on(event: 'execCommandApproval', listener: CodexClientEventListener<ExecApprovalRequestEventMessage>): this;
-  on(
-    event: 'applyPatchApproval',
-    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
-  ): this;
-  on(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
-  on(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
-  on(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
-  on(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
-  on(event: 'historyEntry', listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>): this;
-  on(event: 'mcpTools', listener: CodexClientEventListener<McpListToolsResponseEventMessage>): this;
-  on(event: 'customPrompts', listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>): this;
-  on(event: 'enteredReviewMode', listener: CodexClientEventListener<EnteredReviewModeEventMessage>): this;
-  on(event: 'exitedReviewMode', listener: CodexClientEventListener<ExitedReviewModeEventMessage>): this;
-  on(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
-  on(event: 'error', listener: (error: unknown) => void): this;
-  on(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
-
-  once(event: 'sessionConfigured', listener: CodexClientEventListener<SessionConfiguredEventMessage>): this;
-  once(event: 'execCommandApproval', listener: CodexClientEventListener<ExecApprovalRequestEventMessage>): this;
-  once(
-    event: 'applyPatchApproval',
-    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
-  ): this;
-  once(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
-  once(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
-  once(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
-  once(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
-  once(event: 'historyEntry', listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>): this;
-  once(event: 'mcpTools', listener: CodexClientEventListener<McpListToolsResponseEventMessage>): this;
-  once(event: 'customPrompts', listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>): this;
-  once(event: 'enteredReviewMode', listener: CodexClientEventListener<EnteredReviewModeEventMessage>): this;
-  once(event: 'exitedReviewMode', listener: CodexClientEventListener<ExitedReviewModeEventMessage>): this;
-  once(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
-  once(event: 'error', listener: (error: unknown) => void): this;
-  once(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
-
-  off(event: 'sessionConfigured', listener: CodexClientEventListener<SessionConfiguredEventMessage>): this;
-  off(event: 'execCommandApproval', listener: CodexClientEventListener<ExecApprovalRequestEventMessage>): this;
-  off(
-    event: 'applyPatchApproval',
-    listener: CodexClientEventListener<ApplyPatchApprovalRequestEventMessage>,
-  ): this;
-  off(event: 'notification', listener: CodexClientEventListener<NotificationEventMessage>): this;
-  off(event: 'conversationPath', listener: CodexClientEventListener<ConversationPathEventMessage>): this;
-  off(event: 'shutdownComplete', listener: CodexClientEventListener<ShutdownCompleteEventMessage>): this;
-  off(event: 'turnContext', listener: CodexClientEventListener<TurnContextEventMessage>): this;
-  off(event: 'historyEntry', listener: CodexClientEventListener<GetHistoryEntryResponseEventMessage>): this;
-  off(event: 'mcpTools', listener: CodexClientEventListener<McpListToolsResponseEventMessage>): this;
-  off(event: 'customPrompts', listener: CodexClientEventListener<ListCustomPromptsResponseEventMessage>): this;
-  off(event: 'enteredReviewMode', listener: CodexClientEventListener<EnteredReviewModeEventMessage>): this;
-  off(event: 'exitedReviewMode', listener: CodexClientEventListener<ExitedReviewModeEventMessage>): this;
-  off(event: 'event', listener: CodexClientEventListener<CodexEvent>): this;
-  off(event: 'error', listener: (error: unknown) => void): this;
-  off(event: typeof EVENT_STREAM_CLOSED, listener: () => void): this;
-
-  on(event: string, listener: (...args: unknown[]) => void): this;
-  once(event: string, listener: (...args: unknown[]) => void): this;
-  off(event: string, listener: (...args: unknown[]) => void): this;
-}
 function expandHomePath(input: string): string {
   const trimmed = input.trim();
   if (!trimmed) {

--- a/src/internal/nativeModule.ts
+++ b/src/internal/nativeModule.ts
@@ -10,7 +10,6 @@ export function resolveModuleUrl(
   dir?: string,
 ): string {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-implied-eval
     const fn = fnCtor(`
       try { return import.meta.url; }
       catch (err) { return undefined; }


### PR DESCRIPTION
## Summary
- inline the typed `on`/`once`/`off` overloads inside `CodexClient` to avoid class/interface declaration merging violations
- drop the unused eslint-disable directive in `nativeModule` now that the lint passes without it

## Testing
- pnpm lint
- pnpm coverage

------
https://chatgpt.com/codex/tasks/task_e_68cff91d964c832586480f6882f56417