### PR TITLE
Fix CLI version normalization

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,9 +1,11 @@
 import type { LoadNativeModuleOptions } from './internal/nativeModule';
 import { loadNativeModule } from './internal/nativeModule';
 
+const SEMVER_PATTERN = /\d+\.\d+\.\d+/;
+
 function normalizeVersion(raw: string): string {
   const trimmed = raw.trim();
-  const match = trimmed.match(/0\.\d+\.\d+/);
+  const match = trimmed.match(SEMVER_PATTERN);
   return match ? match[0] : trimmed;
 }
 

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -17,7 +17,7 @@ describe('getCodexCliVersion', () => {
     const version = getCodexCliVersion();
     console.log('[getCodexCliVersion]', version);
     expect(version).toBe('0.39.0');
-    expect(version).toMatch(/^0\.\d+\.\d+$/);
+    expect(version).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
   it('throws if cliVersion is missing', () => {


### PR DESCRIPTION
## Summary
- update CLI version normalization to match any semantic version triple
- relax the version test expectation so it accepts non-zero major versions

## Testing
- npm test
- npm run lint *(fails: pre-existing @typescript-eslint/no-explicit-any violations in src/client/CodexClient.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d089b1a9688325b00a9f284d81e995